### PR TITLE
Adds option for setting cache-control max-age

### DIFF
--- a/metasettings.php
+++ b/metasettings.php
@@ -4,7 +4,7 @@
  * ??
  */
 class MetaSettings {
-  
+
   function __construct($file, $namespace) {
     $this->file = $file;
     $this->plugin = plugin_basename($file);
@@ -30,11 +30,15 @@ class MetaSettings {
     if(!get_option('new_members_only_redirect_root')) {
       add_option('new_members_only_redirect_root', '/wp-login.php?redirect_to=%return_path%');
     }
+
+    if(!get_option('new_members_only_max_age')) {
+        add_option('new_members_only_max_age', 0);
+    }
   }
 
   /**
    * Wrapper for adding settings with the WP Settings API
-   * 
+   *
    * @param string $title    Name of the setting
    * @param array  $options  Setting options array
    * @param string $callback Callback function
@@ -50,8 +54,8 @@ class MetaSettings {
   }
 
   /**
-   * Insert action links for plugin 
-   * 
+   * Insert action links for plugin
+   *
    * @param  array  $links Existing action links for the plugin
    * @param  string $file  File to link to in the actions
    * @return array         New action links
@@ -64,7 +68,7 @@ class MetaSettings {
 
   /**
    * Create admin menu for plugin
-   * 
+   *
    * @return void
    */
   function admin_menu() {
@@ -73,7 +77,7 @@ class MetaSettings {
 
   /**
    * Prefix options with namespace
-   * 
+   *
    * @param  array  $whitelist_options Options to whitelist
    * @return array                     Whitelisted options
    */

--- a/redirect.php
+++ b/redirect.php
@@ -35,7 +35,7 @@ function new_members_only_serve_uploads() {
 
 /**
  * Handle redirect for users when not logged in or viewing whitelisted content
- * 
+ *
  * @param  boolean $root Whether attempting to view root or not
  * @return void
  */
@@ -85,13 +85,15 @@ add_action('init', function () {
     return;
   }
 
+  $max_age = new_members_only_get_max_age();
+
   do_action('new_members_only_redirect');
   if (
       defined('NEW_MEMBERS_ONLY_PASSTHROUGH') ||
       is_user_logged_in() ||
       apply_filters('new_members_only_redirect', false) === true
      ) {
-    header('Cache-Control: private');
+    header('Cache-Control: private, max-age=' . $max_age);
     new_members_only_serve_uploads();
     return;
   }
@@ -111,7 +113,7 @@ add_action('init', function () {
 
   // IP whitelist
   if (new_members_only_current_ip_in_whitelist()) {
-    header('Cache-Control: private');
+    header('Cache-Control: private, max-age=' . $max_age);
     new_members_only_serve_uploads();
     return;
   }
@@ -158,6 +160,15 @@ add_action('init', function () {
     return;
   }
 
-  header('Cache-Control: private');
+  header('Cache-Control: private, max-age=' . $max_age);
   new_members_only_redirect($path === '/');
 }, -99999999999);
+
+function new_members_only_get_max_age()
+{
+    $max_age = (int) get_option('new_members_only_max_age');
+    if($max_age < 0 || $max_age==='') {
+        $max_age = 0;
+    }
+    return $max_age;
+}

--- a/redirect.php
+++ b/redirect.php
@@ -85,7 +85,7 @@ add_action('init', function () {
     return;
   }
 
-  $max_age = new_members_only_get_max_age();
+  $max_age = absint(get_option('new_members_only_max_age'));
 
   do_action('new_members_only_redirect');
   if (
@@ -163,12 +163,3 @@ add_action('init', function () {
   header('Cache-Control: private, max-age=' . $max_age);
   new_members_only_redirect($path === '/');
 }, -99999999999);
-
-function new_members_only_get_max_age()
-{
-    $max_age = (int) get_option('new_members_only_max_age');
-    if($max_age < 0 || $max_age==='') {
-        $max_age = 0;
-    }
-    return $max_age;
-}

--- a/settings.php
+++ b/settings.php
@@ -1,11 +1,11 @@
 <?php
 
 $ms = new MetaSettings(__FILE__, 'new_members_only');
-$ms->add_settings(__('New Members Only', 'membersonly'), array('list_type', 'list_content', 'ip_whitelist', 'redirect', 'redirect_root', 'upload_default'), 'new_members_only_options_page');
+$ms->add_settings(__('New Members Only', 'membersonly'), array('list_type', 'list_content', 'ip_whitelist', 'redirect', 'redirect_root', 'upload_default', 'max_age'), 'new_members_only_options_page');
 
 /**
  * Output settings page content
- * 
+ *
  * @return void
  */
 function new_members_only_options_page() {
@@ -91,6 +91,18 @@ function new_members_only_options_page() {
         </td>
       </tr>
 
+    </table>
+
+    <h3><?php _e('Max Age', 'membersonly') ?></h3>
+
+    <table class="form-table">
+        <tr valign="top">
+            <th scope="row"><label for="new_members_only_max_age"><?php _e('Max age for cache-control header', 'membersonly') ?></label></th>
+            <td>
+                <input type="number" min="0" step="1" name="new_members_only_max_age" id="new_members_only_max_age" value="<?php form_option('new_members_only_max_age') ?>" class="regular-text">
+                <span class="description">Defaults to 0 if not set.</span>
+            </td>
+        </tr>
     </table>
 
     <?php submit_button() ?>


### PR DESCRIPTION
Previously, new-members-only was setting a Cache-Control header of private.
This resulted in some browsers defaulting to a max-age of 0, and re-loading
resources every time. This commit adds an option in the plug-in settings
to set a max-age to the Cache-Control header, which will stop this
happening.

Resolves: https://dxw.zendesk.com/agent/tickets/6565