### PR TITLE
(fix): URI path traversal in `serve_uploads` is no longer possible

### DIFF
--- a/redirect.php
+++ b/redirect.php
@@ -19,7 +19,7 @@ function new_members_only_serve_uploads()
         $realFilePath = realpath($file);
         $realUploadDir = realpath($basedir);
 
-        if (is_file($file) && is_readable($file) && strpos($realFilePath, $realUploadDir.'/') === 0) {
+        if (is_file($file) && is_readable($file) && \Missing\Strings::startsWith($realFilePath, $realUploadDir.'/')) {
             $mime = wp_check_filetype($file);
 
             $type = 'application/octet-stream';

--- a/redirect.php
+++ b/redirect.php
@@ -1,7 +1,9 @@
 <?php
 
-// Handle request for uploaded content
-// @return void
+/**
+ * Handle request for uploaded content
+ * @return void
+ */
 function new_members_only_serve_uploads()
 {
     $req = nmo_strip_query($_SERVER['REQUEST_URI']);
@@ -14,8 +16,10 @@ function new_members_only_serve_uploads()
         $baseurl = preg_replace('%^https?://[^/]+(/.*)$%', '$1', $upload_dir['baseurl']);
         $basedir = $upload_dir['basedir'];
         $file = preg_replace("[^{$baseurl}]", $basedir, $req);
+        $realFilePath = realpath($file);
+        $realUploadDir = realpath($basedir);
 
-        if (is_file($file) && is_readable($file)) {
+        if (is_file($file) && is_readable($file) && strpos($realFilePath, $realUploadDir) === 0) {
             $mime = wp_check_filetype($file);
 
             $type = 'application/octet-stream';

--- a/redirect.php
+++ b/redirect.php
@@ -19,7 +19,7 @@ function new_members_only_serve_uploads()
         $realFilePath = realpath($file);
         $realUploadDir = realpath($basedir);
 
-        if (is_file($file) && is_readable($file) && strpos($realFilePath, $realUploadDir) === 0) {
+        if (is_file($file) && is_readable($file) && strpos($realFilePath, $realUploadDir.'/') === 0) {
             $mime = wp_check_filetype($file);
 
             $type = 'application/octet-stream';


### PR DESCRIPTION
* Part of this sprint is to implement the recommendations
  from the recent PenTest, this was one of those recommendations
* See '2.1.3 Fix the local file include in the new-members-only plugin'
  of the report

Resolves: https://trello.com/c/NE9JaSb0/235-1-2-1-3-fix-the-local-file-include-in-the-new-members-only-plugin