### PR TITLE
Bypass redirection when request is a REST API call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for PHP versions 8.2 and up
+- Support for REST API calls
 
 ### Removed
 

--- a/app/Redirect.php
+++ b/app/Redirect.php
@@ -16,6 +16,10 @@ class Redirect implements \Dxw\Iguana\Registerable
 			return;
 		}
 
+		if (isset($_SERVER['REQUEST_URI']) && str_starts_with($_SERVER['REQUEST_URI'], '/wp-json/')) {
+			return;
+		}
+
 		/** @var int @max_age */
 		$max_age = absint((int) get_option('dxw_members_only_max_age'));
 		/** @var int @max_age_public */

--- a/app/RestAuthenticator.php
+++ b/app/RestAuthenticator.php
@@ -19,6 +19,10 @@ class RestAuthenticator implements \Dxw\Iguana\Registerable
 			return true;
 		}
 
-		return $errors;
+		return new \WP_Error(
+			'rest_forbidden',
+			'You must be authenticated to access the REST API.',
+			[ 'status' => 401 ]
+		);
 	}
 }

--- a/app/RestAuthenticator.php
+++ b/app/RestAuthenticator.php
@@ -4,6 +4,12 @@ namespace Dxw\MembersOnly;
 
 class RestAuthenticator implements \Dxw\Iguana\Registerable
 {
+	/** @var string[] */
+	private const ENDPOINT_ALLOWLIST = [
+		'/wp/v2/posts',
+		'/wp/v2/categories',
+	];
+
 	public function register(): void
 	{
 		add_filter('rest_authentication_errors', [$this, 'authenticate'], 10, 1);
@@ -15,14 +21,34 @@ class RestAuthenticator implements \Dxw\Iguana\Registerable
 	 */
 	public function authenticate($errors)
 	{
-		if (is_user_logged_in()) {
-			return true;
+		$loggedIn = is_user_logged_in();
+		if ($loggedIn) {
+			foreach (self::ENDPOINT_ALLOWLIST as $allowed) {
+				if ($this->requestMatchesEndpoint($allowed)) {
+					return true;
+				}
+			}
 		}
 
 		return new \WP_Error(
 			'rest_forbidden',
-			'You must be authenticated to access the REST API.',
-			[ 'status' => 401 ]
+			'You must be authenticated to access this REST API endpoint.',
+			['status' => 401]
 		);
+	}
+
+	private function requestMatchesEndpoint(string $endpoint): bool
+	{
+		$request_uri = '';
+		if (isset($_SERVER['REQUEST_URI'])) {
+			$request_uri = strtolower($_SERVER['REQUEST_URI']);
+		}
+
+		$rest_route = '';
+		if (isset($_REQUEST['rest_route']) && is_string($_REQUEST['rest_route'])) {
+			$rest_route = strtolower($_REQUEST['rest_route']);
+		}
+
+		return str_contains($request_uri, $endpoint) || str_contains($rest_route, $endpoint);
 	}
 }

--- a/app/RestAuthenticator.php
+++ b/app/RestAuthenticator.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Dxw\MembersOnly;
+
+class RestAuthenticator implements \Dxw\Iguana\Registerable
+{
+	public function register(): void
+	{
+	}
+}

--- a/app/RestAuthenticator.php
+++ b/app/RestAuthenticator.php
@@ -21,19 +21,24 @@ class RestAuthenticator implements \Dxw\Iguana\Registerable
 	 */
 	public function authenticate($errors)
 	{
-		$loggedIn = is_user_logged_in();
-		if ($loggedIn) {
-			foreach (self::ENDPOINT_ALLOWLIST as $allowed) {
-				if ($this->requestMatchesEndpoint($allowed)) {
-					return true;
-				}
+		if (!is_user_logged_in()) {
+			return new \WP_Error(
+				'rest_not_logged_in',
+				'You must be authenticated to access this endpoint.',
+				['status' => 401]
+			);
+		}
+
+		foreach (self::ENDPOINT_ALLOWLIST as $allowed) {
+			if ($this->requestMatchesEndpoint($allowed)) {
+				return true;
 			}
 		}
 
 		return new \WP_Error(
 			'rest_forbidden',
-			'You must be authenticated to access this REST API endpoint.',
-			['status' => 401]
+			'You do not have permission to access this endpoint.',
+			['status' => 403]
 		);
 	}
 

--- a/app/RestAuthenticator.php
+++ b/app/RestAuthenticator.php
@@ -4,12 +4,6 @@ namespace Dxw\MembersOnly;
 
 class RestAuthenticator implements \Dxw\Iguana\Registerable
 {
-	/** @var string[] */
-	private const ENDPOINT_ALLOWLIST = [
-		'/wp/v2/posts',
-		'/wp/v2/categories',
-	];
-
 	public function register(): void
 	{
 		add_filter('rest_authentication_errors', [$this, 'authenticate'], 10, 1);
@@ -29,8 +23,11 @@ class RestAuthenticator implements \Dxw\Iguana\Registerable
 			);
 		}
 
-		foreach (self::ENDPOINT_ALLOWLIST as $allowed) {
-			if ($this->requestMatchesEndpoint($allowed)) {
+		$endpoint_allow_list = explode("\n", (string) get_option('dxw_members_only_endpoint_allow_list'));
+		foreach ($endpoint_allow_list as $endpoint) {
+			$endpoint = trim($endpoint);
+
+			if (!empty($endpoint) && $this->requestMatchesEndpoint($endpoint)) {
 				return true;
 			}
 		}

--- a/app/RestAuthenticator.php
+++ b/app/RestAuthenticator.php
@@ -6,5 +6,15 @@ class RestAuthenticator implements \Dxw\Iguana\Registerable
 {
 	public function register(): void
 	{
+		add_filter('rest_authentication_errors', [$this, 'authenticate'], 10, 1);
+	}
+
+	/**
+	 * @param \WP_Error|null|true $errors
+	 * @return \WP_Error|null|true
+	 */
+	public function authenticate($errors)
+	{
+		return null;
 	}
 }

--- a/app/RestAuthenticator.php
+++ b/app/RestAuthenticator.php
@@ -15,6 +15,10 @@ class RestAuthenticator implements \Dxw\Iguana\Registerable
 	 */
 	public function authenticate($errors)
 	{
-		return null;
+		if (is_user_logged_in()) {
+			return true;
+		}
+
+		return $errors;
 	}
 }

--- a/app/di.php
+++ b/app/di.php
@@ -3,3 +3,4 @@
 $registrar->addInstance(new \Dxw\MembersOnly\Upgrade());
 $registrar->addInstance(new \Dxw\MembersOnly\Redirect());
 $registrar->addInstance(new \Dxw\MembersOnly\Upload());
+$registrar->addInstance(new \Dxw\MembersOnly\RestAuthenticator());

--- a/settings.php
+++ b/settings.php
@@ -13,6 +13,7 @@ function dxw_members_only_metasettings(): void
 	  'list_type',
 	  'list_content',
 	  'ip_whitelist',
+	  'endpoint_allow_list',
 	  'referrer_allow_list',
 	  'redirect',
 	  'redirect_root',
@@ -68,6 +69,22 @@ function dxw_members_only_options_page()
 
     </table>
 
+    <h3><?php _e('REST Endpoint Allow list') ?></h3>
+    <p><?php _e('Enter a list of REST API endpoints that can be accessed when logged in.', 'dxwmembersonly') ?></p>
+
+    <table class="form-table">
+
+      <tr valign="top">
+        <th scope="row"><label for="dxw_members_only_rest_endpoint_allow_list"><?php _e('List of endpoints', 'dxwmembersonly') ?></label></th>
+        <td>
+          <textarea cols="30" rows="5" name="dxw_members_only_rest_endpoint_allow_list" id="dxw_members_only_rest_endpoint_allow_list" class="large-text code"><?php echo esc_html((string) get_option('dxw_members_only_rest_endpoint_allow_list')) ?></textarea>
+          <br>
+          <span class="description"><?php _e('One API endpoint (e.g. /wp/v2/posts) per line.', 'dxwmembersonly') ?></span>
+        </td>
+      </tr>
+
+    </table>
+
     <h3><?php _e('Referrer Allow list') ?></h3>
     <p><?php _e('Enter a list of internal referrers to whitelist.', 'dxwmembersonly') ?></p>
     <p><?php _e('This is for enabling certain plugins such as Nelio AB to function correctly, do not use unless required', 'dxwmembersonly') ?></p>
@@ -79,7 +96,7 @@ function dxw_members_only_options_page()
         <td>
           <textarea cols="30" rows="5" name="dxw_members_only_referrer_allow_list" id="dxw_members_only_referrer_allow_list" class="large-text code"><?php echo esc_html((string) get_option('dxw_members_only_referrer_allow_list')) ?></textarea>
           <br>
-          <span class="description"><?php _e('One address per line, do not include the domain (eg /admin.php?page=test)', 'dxwmembersonly') ?></span>
+          <span class="description"><?php _e('One address per line, do not include the domain (e.g. /admin.php?page=test)', 'dxwmembersonly') ?></span>
         </td>
       </tr>
 

--- a/spec/redirect.spec.php
+++ b/spec/redirect.spec.php
@@ -35,16 +35,16 @@ describe(Dxw\MembersOnly\Redirect::class, function () {
 		});
 
 		context('When request is a REST API call', function () {
-            it('immediately returns', function () {
-                $_SERVER['REQUEST_URI'] = '/wp-json/wp/v2/posts';
-                allow('defined')->toBeCalled()->with('WP_CLI_ROOT')->andReturn(true);
+			it('immediately returns', function () {
+				$_SERVER['REQUEST_URI'] = '/wp-json/wp/v2/posts';
+				allow('defined')->toBeCalled()->with('WP_CLI_ROOT')->andReturn(true);
 
-                expect('get_option')->not->toBeCalled();
-                expect('header')->not->toBeCalled();
+				expect('get_option')->not->toBeCalled();
+				expect('header')->not->toBeCalled();
 
-                $this->redirect->handle_request();
-                unset($_SERVER);
-            });
+				$this->redirect->handle_request();
+				unset($_SERVER);
+			});
 		});
 
 		context('WP_CLI_ROOT is not defined', function () {

--- a/spec/redirect.spec.php
+++ b/spec/redirect.spec.php
@@ -33,6 +33,20 @@ describe(Dxw\MembersOnly\Redirect::class, function () {
 				$this->redirect->handle_request();
 			});
 		});
+
+		context('When request is a REST API call', function () {
+            it('immediately returns', function () {
+                $_SERVER['REQUEST_URI'] = '/wp-json/wp/v2/posts';
+                allow('defined')->toBeCalled()->with('WP_CLI_ROOT')->andReturn(true);
+
+                expect('get_option')->not->toBeCalled();
+                expect('header')->not->toBeCalled();
+
+                $this->redirect->handle_request();
+                unset($_SERVER);
+            });
+		});
+
 		context('WP_CLI_ROOT is not defined', function () {
 			beforeEach(function () {
 				allow('defined')->toBeCalled()->with('WP_CLI_ROOT')->andReturn(false);

--- a/spec/rest_authenticator.spec.php
+++ b/spec/rest_authenticator.spec.php
@@ -1,0 +1,11 @@
+<?php
+
+describe(Dxw\MembersOnly\RestAuthenticator::class, function () {
+	beforeEach(function () {
+		$this->restAuthenticator = new \Dxw\MembersOnly\RestAuthenticator();
+	});
+
+	it('implements the registerable interface', function () {
+		expect($this->restAuthenticator)->toBeAnInstanceOf(\Dxw\Iguana\Registerable::class);
+	});
+});

--- a/spec/rest_authenticator.spec.php
+++ b/spec/rest_authenticator.spec.php
@@ -26,6 +26,9 @@ describe(Dxw\MembersOnly\RestAuthenticator::class, function () {
 			$_SERVER['REQUEST_URI'] = '';
 			$_REQUEST['rest_route'] = '';
 
+			$allowed_endpoints = "/wp/v2/posts\n";
+			allow('get_option')->toBeCalled()->andReturn($allowed_endpoints);
+
 			$this->wpError = Double::instance([
 				'class' => '\WP_Error',
 			]);

--- a/spec/rest_authenticator.spec.php
+++ b/spec/rest_authenticator.spec.php
@@ -1,12 +1,14 @@
 <?php
 
+use Kahlan\Plugin\Double;
+
 describe(Dxw\MembersOnly\RestAuthenticator::class, function () {
 	beforeEach(function () {
 		$this->restAuthenticator = new \Dxw\MembersOnly\RestAuthenticator();
 	});
 
 	it('implements the registerable interface', function () {
-		expect($this->restAuthenticator)->toBeAnInstanceOf(\Dxw\Iguana\Registerable::class);
+		expect($this->restAuthenticator)->toBeAnInstanceOf(\dxw\iguana\registerable::class);
 	});
 
 	describe('->register()', function () {
@@ -25,6 +27,17 @@ describe(Dxw\MembersOnly\RestAuthenticator::class, function () {
 
 			$actual = $this->restAuthenticator->authenticate(false);
 			expect($actual)->toBe(true);
+		});
+
+		it('blocks request if not authenticated', function () {
+			$wpError = Double::instance([
+				'class' => '\WP_Error',
+			]);
+
+			allow('is_user_logged_in')->toBeCalled()->andReturn(false);
+
+			$actual = $this->restAuthenticator->authenticate(true);
+			expect($actual)->toBeAnInstanceOf($wpError);
 		});
 	});
 });

--- a/spec/rest_authenticator.spec.php
+++ b/spec/rest_authenticator.spec.php
@@ -22,22 +22,40 @@ describe(Dxw\MembersOnly\RestAuthenticator::class, function () {
 	});
 
 	describe('->authenticate()', function () {
-		it('allows access if the user is already logged in', function () {
+		beforeEach(function () {
+			$_SERVER['REQUEST_URI'] = '';
+			$_REQUEST['rest_route'] = '';
+
+			$this->wpError = Double::instance([
+				'class' => '\WP_Error',
+			]);
+		});
+
+		it('allows access for logged-in users on whitelisted endpoints', function () {
 			allow('is_user_logged_in')->toBeCalled()->andReturn(true);
 
-			$actual = $this->restAuthenticator->authenticate(false);
+			$_SERVER['REQUEST_URI'] = '/wp/v2/posts';
+
+			$actual = $this->restAuthenticator->authenticate(null);
 			expect($actual)->toBe(true);
 		});
 
-		it('blocks request if not authenticated', function () {
-			$wpError = Double::instance([
-				'class' => '\WP_Error',
-			]);
+		it('blocks logged-in users for non-whitelisted endpoints', function () {
+			allow('is_user_logged_in')->toBeCalled()->andReturn(true);
 
+			$_SERVER['REQUEST_URI'] = '/wp/v2/non-whitelisted';
+
+			$actual = $this->restAuthenticator->authenticate(null);
+			expect($actual)->toBeAnInstanceOf($this->wpError);
+		});
+
+		it('blocks request if not authenticated', function () {
 			allow('is_user_logged_in')->toBeCalled()->andReturn(false);
 
-			$actual = $this->restAuthenticator->authenticate(true);
-			expect($actual)->toBeAnInstanceOf($wpError);
+			$_SERVER['REQUEST_URI'] = '/wp/v2/posts';
+
+			$actual = $this->restAuthenticator->authenticate(null);
+			expect($actual)->toBeAnInstanceOf($this->wpError);
 		});
 	});
 });

--- a/spec/rest_authenticator.spec.php
+++ b/spec/rest_authenticator.spec.php
@@ -18,4 +18,13 @@ describe(Dxw\MembersOnly\RestAuthenticator::class, function () {
 			$this->restAuthenticator->register();
 		});
 	});
+
+	describe('->authenticate()', function () {
+		it('allows access if the user is already logged in', function () {
+			allow('is_user_logged_in')->toBeCalled()->andReturn(true);
+
+			$actual = $this->restAuthenticator->authenticate(false);
+			expect($actual)->toBe(true);
+		});
+	});
 });

--- a/spec/rest_authenticator.spec.php
+++ b/spec/rest_authenticator.spec.php
@@ -8,4 +8,14 @@ describe(Dxw\MembersOnly\RestAuthenticator::class, function () {
 	it('implements the registerable interface', function () {
 		expect($this->restAuthenticator)->toBeAnInstanceOf(\Dxw\Iguana\Registerable::class);
 	});
+
+	describe('->register()', function () {
+		it('adds the filter', function () {
+			allow('add_filter')->toBeCalled();
+
+			expect('add_filter')->toBeCalled()->once()->with('rest_authentication_errors', [$this->restAuthenticator, 'authenticate'], 10, 1);
+
+			$this->restAuthenticator->register();
+		});
+	});
 });


### PR DESCRIPTION
## Description
Previously, all requests were being redirected to the login, regardless of whether it was an authenticated REST API call or not.

Now, a check was added to exit early in the redirection functionality to allow said requests.

See related ticket: https://trello.com/c/s9aZ8wAg/627-rest-with-application-passwords-usable-via-dxw-members-only-request-from-joseph


## How to Test
1. Define the following in `functions.php` to allow the usage of Applications
```
define( 'WP_ENVIRONMENT_TYPE', 'local' );
```
2. Create an Application in the [admin Dashboard ](http://localhost/wp-admin/profile.php)
3. Run a curl request to confirm the REST API is successful
```
curl --user "admin:<your_application_password>" http://localhost/wp-json/wp/v2/posts   
```
4. Ensure you're logged out and run the following in the browser and confirm you can't get through:
```
fetch('/wp-json/wp/v2/posts')
  .then(response => response.json())
  .then(data => console.log(data))
  .catch(err => console.error(err));
 ```


