### PR TITLE
docker-compose: By default bind only to localhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for PHP versions 8.2 and up
+- Docker bound to localhost
 
 ### Removed
 

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -4,7 +4,8 @@ services:
   wordpress:
     image: thedxw/wpc-wordpress:php8.2
     ports:
-      - "80:80"
+      - "127.0.0.1:80:80"
+      - "[::1]:80:80"
     links:
       - mysql
     volumes:
@@ -15,7 +16,8 @@ services:
   mysql:
     image: mariadb:10
     ports:
-      - "3306:3306"
+      - "127.0.0.1:3306:3306"
+      - "[::1]:3306:3306"
     environment:
        MYSQL_ROOT_PASSWORD: foobar
        MYSQL_DATABASE: wordpress


### PR DESCRIPTION
To avoid allowing the services to run on all available networks by default bind the services to localhost.

- [ ] Version number has been bumped
- [ ] Major version number tag moved after release (see [docs](README.md#Versioning))
