### PR TITLE
Fix/ci test

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,9 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const chromiumDevice = process.env.CI
+  ? { ...devices['Desktop Chrome'], channel: 'chrome' as const }
+  : { ...devices['Desktop Chrome'] };
+
 /**
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
@@ -36,7 +40,7 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: chromiumDevice,
     }
 
     /* Test against mobile viewports. */

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -31,8 +31,8 @@ if [ -f package.json ]; then
   echo "==> Installing NPM dependencies..."
   if [ -z "$CI" ]; then
     npm install
+    npx playwright install chromium
   else
-    npm ci
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci
   fi
-  npx playwright install --with-deps
 fi


### PR DESCRIPTION
CI tests were failing on Github - see PR https://github.com/dxw/dxw-members-only/pull/68
It seems like this was being caused by the CI tests requiring that Playwright download a copy of Chrome browser as part of the test. This was causing a timeout. 

In script/bootstrap, CI now runs npm ci with PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1, so it does not spend time downloading Playwright-managed browsers. Local setup still installs Chromium for developers.
In playwright.config.ts, Playwright uses the system Chrome channel when running in CI, while continuing to use the default local Chromium setup outside CI.

- [ ] Version number has been bumped
- [ ] Major version number tag moved after release (see [docs](README.md#Versioning))
 