### PR TITLE
Fix/22060 allow password reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Allow password reset to access admin-ajax.php
+
 [v5.0.0] - 2026-06-19
 
 ### Changed

--- a/app/Redirect.php
+++ b/app/Redirect.php
@@ -49,6 +49,11 @@ class Redirect implements \Dxw\Iguana\Registerable
 			return;
 		}
 
+		// Always allow POST /wp-admin/admin-ajax.php with action=generate-password to allow password reset flow
+		if (\Missing\Strings::endsWith($path, 'wp-admin/admin-ajax.php') && isset($_POST['action']) && $_POST['action'] === 'generate-password') {
+			return;
+		}
+
 		// IP & referrer allow lists
 		if ($this->current_ip_in_whitelist() || $this->referrer_in_allow_list()) {
 			header('Cache-Control: private, max-age=' . $max_age);

--- a/script/cibuild
+++ b/script/cibuild
@@ -10,7 +10,7 @@ script/test
 script/server -d
 
 # Wait for the MySQL container to be ready
-while ! docker compose -f local/docker-compose.yml exec wordpress mysqladmin ping -hmysql -pfoobar --silent >/dev/null; do
+while ! docker compose -f local/docker-compose.yml exec wordpress mysqladmin ping -hmysql -pfoobar --skip-ssl --silent >/dev/null; do
 	echo "===> Waiting for MySQL instance to be ready..."
 	sleep 5
 done

--- a/script/setup
+++ b/script/setup
@@ -23,7 +23,7 @@ if ! docker compose -f local/docker-compose.yml ps | grep -q Up; then
 fi
 
 # Wait for the MySQL container to be ready
-while ! docker compose -f local/docker-compose.yml exec wordpress mysqladmin ping -hmysql -pfoobar --silent >/dev/null; do
+while ! docker compose -f local/docker-compose.yml exec wordpress mysqladmin ping -hmysql -pfoobar --skip-ssl --silent >/dev/null; do
 	echo "===> Waiting for MySQL instance to be ready..."
 	sleep 5
 done


### PR DESCRIPTION
## Description

Password reset flow breaking with 'Your password reset link appears to be invalid' on bikeshed
Ticket: https://dxw.zendesk.com/agent/tickets/22060

## Test
Try reset password from login screen (with this dxw-members-only plugin enabled)
It will fail as above on master/head branch, but should work on this branch.
(You will need to check mailcatcher at http://localhost:1080/ for emails)

- [ ] Version number has been bumped
- [ ] Major version number tag moved after release (see [docs](README.md#Versioning))
